### PR TITLE
Always Title RPC names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/horizon-games/protoc-gen-twirp_ts
+
+go 1.13
+
+require github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/template.go
+++ b/template.go
@@ -282,7 +282,7 @@ func objectToField(fv fieldValues) string {
 
 	switch t {
 	case "string", "number", "boolean":
-		return fmt.Sprintf("m['%s']!", fv.Name)
+		return fmt.Sprintf("%s(m['%s'])!", upperCaseFirst(t), fv.Name)
 	}
 
 	if fv.IsEnum {

--- a/template.go
+++ b/template.go
@@ -164,7 +164,7 @@ export class {{.Name}} implements {{.Interface}} {
   {{range .Methods}}
   public {{.Name | methodName}}(params: {{.InputType}}, headers: object = {}): Promise<{{.OutputType}}> {
     return this.fetch(
-      this.url('{{.Name}}'),
+      this.url('{{.Name | title}}'),
       createTwirpRequest(params, headers)
     ).then((res) => {
       if (!res.ok) {
@@ -249,6 +249,7 @@ func compileAndExecute(tpl string, data interface{}) (string, error) {
 		"fieldType":     fieldType,
 		"methodName":    methodName,
 		"objectToField": objectToField,
+		"title":         strings.Title,
 	}
 
 	t, err := template.New("").Funcs(funcMap).Parse(tpl)


### PR DESCRIPTION
It is allowed in protobuf to create an rpc with a lower camelCase. However, in the URL path, Twirp always converts to PascalCase. This generator should ensure the same thing 

PS. added Go Modules support. 